### PR TITLE
HTML head content not being inserted

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "lint": "gulp lint",
     "lint-js": "gulp lint",
     "lint-css": "gulp validate",
-    "build": "gulp build && tweego -f $npm_package_config_format -m src/modules/ -o dist/index.html project && opn dist/index.html",
-    "testmode": "gulp build && tweego -f $npm_package_config_format -t -m src/modules/ -o dist/index.html project && opn dist/index.html",
-    "tweegobuild": "tweego -f $npm_package_config_format -m src/modules/ -o dist/index.html project",
-    "build-win": "gulp build && tweego -f %npm_package_config_format% -m src/modules/ -o dist/index.html project && opn dist/index.html",
-    "testmode-win": "gulp build && tweego -f %npm_package_config_format% -t -m src/modules/ -o dist/index.html project && opn dist/index.html",
-    "tweegobuild-win": "tweego -f %npm_package_config_format% -m src/modules/ -o dist/index.html project"
+    "build": "gulp build && tweego -f $npm_package_config_format -m src/modules/ --head=src/modules/head-content.html -o dist/index.html project && opn dist/index.html",
+    "testmode": "gulp build && tweego -f $npm_package_config_format -t -m src/modules/ --head=src/modules/head-content.html -o dist/index.html project && opn dist/index.html",
+    "tweegobuild": "tweego -f $npm_package_config_format -m src/modules/ --head=src/modules/head-content.html -o dist/index.html project",
+    "build-win": "gulp build && tweego -f %npm_package_config_format% -m src/modules/ --head=src/modules/head-content.html -o dist/index.html project && opn dist/index.html",
+    "testmode-win": "gulp build && tweego -f %npm_package_config_format% -t -m src/modules/ --head=src/modules/head-content.html -o dist/index.html project && opn dist/index.html",
+    "tweegobuild-win": "tweego -f %npm_package_config_format% -m src/modules/ --head=src/modules/head-content.html -o dist/index.html project"
   },
   "keywords": [
     "twine",

--- a/src/modules/favicon.html
+++ b/src/modules/favicon.html
@@ -1,1 +1,0 @@
-<link rel="icon" type="image/png" href="./assets/favicon.png" />

--- a/src/modules/head-content.html
+++ b/src/modules/head-content.html
@@ -1,0 +1,1 @@
+<link rel="icon" type="image/png" href="./assets/favicon.png" />


### PR DESCRIPTION
This fixes issue #8 

**Summary**

The current ```-o src/modules/``` option on the tweego build scripts does not add any html content to the output file. The [tweego docs](https://www.motoslave.net/tweego/docs/#usage-options) indicate this is only used for adding the appropriate tags for css, js, and various fonts to the head tag. ```--head``` is required for adding as-is HTML snippets.

**Details**
* Refactor/rename favicon.html to head-content.html. 
  - This file can be used to contain any content to be inserted into the ```<head>``` element of the ```dist/index.html``` output rather than having to extend the tweego build command for multiple html snippets.

* Refactored package.json tweego build scripts
  - Added  ```--head=src/modules/head-content.html``` to tweego build scripts
